### PR TITLE
fix: switch build ‘target’ from ‘web’ to ‘node’, fixes #15

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,6 @@
     "babel": {
       "presets": ["@babel/preset-react"]
     },
-    "target": "web"
+    "target": "node"
   }
 }


### PR DESCRIPTION
I have tested the module built with this modification in Node’s Server Side Rendering and it does not cause any error, since there is no reference to `window` anymore.