### PR TITLE
package.json update to braintree-web-drop-in-react version

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -3,7 +3,7 @@
     "start": "parcel index.html"
   },
   "dependencies": {
-    "braintree-web-drop-in-react": "file:..",
+    "braintree-web-drop-in-react": "^1.1.1",
     "react": "^16.13.1",
     "react-dom": "^16.13.1"
   },


### PR DESCRIPTION
I followed your instructions in [your example file](https://github.com/Cretezy/braintree-web-drop-in-react/tree/master/example) and it wasn't working. It took me a while to figure out it wasn't working because under dependencies, it said `file:..` rather than an actual version.